### PR TITLE
ci: add golangci-lint v2 checks

### DIFF
--- a/.github/workflows/actions-security.yml
+++ b/.github/workflows/actions-security.yml
@@ -1,0 +1,27 @@
+name: Actions Security
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  actions-security:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install aqua tools
+        uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5
+        with:
+          aqua_version: v2.56.6
+      - name: Check pinned actions
+        run: pinact run --check
+      - name: Audit GitHub Actions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: zizmor --format github .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+      - name: Test library
+        run: go test .
+      - name: Compile WebAssembly example
+        env:
+          GOOS: js
+          GOARCH: wasm
+        run: go test -c ./example/gominesweeper -o /tmp/gominesweeper-example.test.wasm
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+      - name: Install aqua tools
+        uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5
+        with:
+          aqua_version: v2.56.6
+      - name: Lint library
+        run: golangci-lint run .
+      - name: Lint WebAssembly example
+        env:
+          GOOS: js
+          GOARCH: wasm
+        run: golangci-lint run ./example/gominesweeper

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,6 @@ linters:
   settings:
     staticcheck:
       checks:
-        # The legacy receive loop intentionally processes at most one message.
         - -SA4004
 
 formatters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,13 @@
+version: "2"
+
+linters:
+  settings:
+    staticcheck:
+      checks:
+        # The legacy receive loop intentionally processes at most one message.
+        - -SA4004
+
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,11 +1,5 @@
 version: "2"
 
-linters:
-  settings:
-    staticcheck:
-      checks:
-        - -SA4004
-
 formatters:
   enable:
     - gofmt

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -1,0 +1,8 @@
+registries:
+  - type: standard
+    ref: v4.554.0
+
+packages:
+  - name: golangci/golangci-lint@v2.13.1
+  - name: suzuki-shunsuke/pinact@v4.1.1
+  - name: zizmorcore/zizmor@v1.29.0

--- a/example/gominesweeper/gominesiper.go
+++ b/example/gominesweeper/gominesiper.go
@@ -45,27 +45,24 @@ func main() {
 
 	go func() {
 		sendCh := minesiper.GetNotify()
-		for {
-			select {
-			case changes := <-sendCh:
-				for ci := range changes {
-					var color string
-					if ci.State == gominesweeper.Bomb {
-						color = "#FF0000"
-					} else if (ci.X+ci.Y)%2 == 0 {
-						color = "#FFFFEE"
-					} else {
-						color = "#FFFF99"
-					}
-					canvasCtx.Set("fillStyle", color)
-					canvasCtx.Call("fillRect", ci.X*cellSize, ci.Y*cellSize, cellSize, cellSize)
-					canvasCtx.Set("fillStyle", "black")
-					canvasCtx.Set("font", fmt.Sprintf(fontFormat, cellSize/2))
-					if ci.State == gominesweeper.Bomb {
-						canvasCtx.Call("fillText", "x", ci.X*cellSize, (ci.Y+1)*cellSize)
-					} else {
-						canvasCtx.Call("fillText", ci.NumOfNearbyBomb, ci.X*cellSize, (ci.Y+1)*cellSize)
-					}
+		for changes := range sendCh {
+			for ci := range changes {
+				var color string
+				if ci.State == gominesweeper.Bomb {
+					color = "#FF0000"
+				} else if (ci.X+ci.Y)%2 == 0 {
+					color = "#FFFFEE"
+				} else {
+					color = "#FFFF99"
+				}
+				canvasCtx.Set("fillStyle", color)
+				canvasCtx.Call("fillRect", ci.X*cellSize, ci.Y*cellSize, cellSize, cellSize)
+				canvasCtx.Set("fillStyle", "black")
+				canvasCtx.Set("font", fmt.Sprintf(fontFormat, cellSize/2))
+				if ci.State == gominesweeper.Bomb {
+					canvasCtx.Call("fillText", "x", ci.X*cellSize, (ci.Y+1)*cellSize)
+				} else {
+					canvasCtx.Call("fillText", ci.NumOfNearbyBomb, ci.X*cellSize, (ci.Y+1)*cellSize)
 				}
 			}
 		}

--- a/gominesiper.go
+++ b/gominesiper.go
@@ -102,39 +102,40 @@ func (c *cell) collectRecievedMessage(recieved ChangedInfo) {
 }
 
 func (c *cell) recieve(hh, ww int, nn position, ccf <-chan ChangedInfo) {
-	for recieved := range ccf {
-		to := position{row: recieved.Y, column: recieved.X}
-		defer close(c.to[to])
-		if c.hasBomb {
-			c.to[to] <- ChangedInfo{X: c.position.column, Y: c.position.row, State: Bomb}
-			// close(c.to[to])
-			return
-		}
-		if c.NearbyBombNum > 0 {
-			ci := ChangedInfo{X: c.position.column, Y: c.position.row, State: Opened, NumOfNearbyBomb: c.NearbyBombNum}
-			c.to[to] <- ci
-			// close(c.to[to])
-			c.canPress()
-			c.notify(ci)
-			return
-		}
-		// response
-		// send したあとのレスポンスを待つ？
-		// 送信した数だけレスポンスが来るはず
-		c.collectRecievedMessage(recieved)
-		if c.canPress() {
-			return
-		}
-		// response
-		// すべてレスポンスされるまで待つ
-		ci := c.send(to)
-		ci.NumOfNearbyBomb = c.NearbyBombNum
-		c.notify(ci)
-		c.to[to] <- ci
-		// close(c.to[to])
-		// fmt.Printf("recived (%d, %d):%v\n", hh, ww, nn)
+	recieved, ok := <-ccf
+	if !ok {
 		return
 	}
+	to := position{row: recieved.Y, column: recieved.X}
+	defer close(c.to[to])
+	if c.hasBomb {
+		c.to[to] <- ChangedInfo{X: c.position.column, Y: c.position.row, State: Bomb}
+		// close(c.to[to])
+		return
+	}
+	if c.NearbyBombNum > 0 {
+		ci := ChangedInfo{X: c.position.column, Y: c.position.row, State: Opened, NumOfNearbyBomb: c.NearbyBombNum}
+		c.to[to] <- ci
+		// close(c.to[to])
+		c.canPress()
+		c.notify(ci)
+		return
+	}
+	// response
+	// send したあとのレスポンスを待つ？
+	// 送信した数だけレスポンスが来るはず
+	c.collectRecievedMessage(recieved)
+	if c.canPress() {
+		return
+	}
+	// response
+	// すべてレスポンスされるまで待つ
+	ci := c.send(to)
+	ci.NumOfNearbyBomb = c.NearbyBombNum
+	c.notify(ci)
+	c.to[to] <- ci
+	// close(c.to[to])
+	// fmt.Printf("recived (%d, %d):%v\n", hh, ww, nn)
 }
 
 // wake start goroutine each `cell.from`.


### PR DESCRIPTION
## Summary
- pin golangci-lint v2.13.1, pinact, and zizmor with aqua
- add a golangci-lint v2 configuration with gofmt and goimports formatters
- run lint and formatter checks for both the library and WebAssembly example on pushes and pull requests
- address the default staticcheck findings by expressing the one-message receive directly and simplifying a channel receive loop
- add tests/compilation checks using the Go version source of truth in go.mod
- add aqua-managed pinact and zizmor Actions security checks with SHA-pinned actions and least-privilege permissions

The repository uses Go 1.19 in go.mod and had no Go 1.27 setting. This change preserves the existing Go version and makes CI read it from go.mod; no Go downgrade was made. No linters or individual checks are disabled.

## Validation
- golangci-lint config verify
- golangci-lint run --allow-parallel-runners . (0 issues)
- GOOS=js GOARCH=wasm golangci-lint run --allow-parallel-runners ./example/gominesweeper (0 issues)
- go test .
- GOOS=js GOARCH=wasm go test -c ./example/gominesweeper
- pinact run --check
- zizmor --format github .
- git diff --check
- search for linters.disable, default: none, --disable, and -D (no matches)