### PR TITLE
ci: pass GitHub tokens to security checks

### DIFF
--- a/.github/workflows/actions-security.yml
+++ b/.github/workflows/actions-security.yml
@@ -21,6 +21,8 @@ jobs:
           aqua_version: v2.56.6
       - name: Check pinned actions
         run: pinact run --check
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
       - name: Audit GitHub Actions
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Pass the GitHub token using environment variables supported by pinact and zizmor.
- Keep the existing read-only workflow permissions.

## Verification

- `pinact run --check`
- `zizmor --format github .`
